### PR TITLE
Reformatted table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,79 +15,80 @@ Questions are rated according to their difficulty:
 
 The table below shows which topics are covered in which courses. Links are to existing pages in Pythonorama. Note that CS 171 is taught in C, but the concepts are very similar between C and Python. DSCI 140 is taught in Python by Peter Drake, but in R by some other instructors.
 
-Topic | CS 171<br>(CS1) | CS 172<br>(CS2) | CS 383<br>(Algo) | CS 488<br>(SofDev) | DSCI 140<br>(DataSci)
--|-|-|-|-|-
+Topic | CS 171<br>(CS1) | CS 172<br>(CS2) | CS 369<br>(AI & ML) | CS 383<br>(Algo) | CS 488<br>(SofDev) | DSCI 140<br>(DataSci)
+-|-|-|-|-|-|-
 **Development Tools**
-&nbsp;&nbsp;&nbsp;&nbsp;[Command Line](development_tools/command_line.md) | x | x | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;[Visual Studio Code](development_tools/vs_code.md) | | x | | |
-&nbsp;&nbsp;&nbsp;&nbsp;PyCharm | | | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;Git | | | | x |
-&nbsp;&nbsp;&nbsp;&nbsp;Jupyter / Google Colab | | | | | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Command Line](development_tools/command_line.md) | x | x | | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Visual Studio Code](development_tools/vs_code.md) | | x | | | |
+&nbsp;&nbsp;&nbsp;&nbsp;PyCharm | | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Git | | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Jupyter / Google Colab | | | | | | x
 **Control Structures**
-&nbsp;&nbsp;&nbsp;&nbsp;[Your First Program](control_structures/your_first_program.md) | x | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[If Statements](control_structures/if_else.md) | x | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[Loops](control_structures/loops.md) | x | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[Functional Decomposition](control_structures/functional_decomposition.md) | x | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[Recursion](control_structures/recursion.md) | | x | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;Higher-Order Functions | | | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Your First Program](control_structures/your_first_program.md) | x | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[If Statements](control_structures/if_else.md) | x | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Loops](control_structures/loops.md) | x | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Functional Decomposition](control_structures/functional_decomposition.md) | x | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Recursion](control_structures/recursion.md) | | x | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Higher-Order Functions | | | x | x | x |
 **Data Structures**
-&nbsp;&nbsp;&nbsp;&nbsp;[Built-in Types](data_structures/built_in_types.md) | x | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[Operators](data_structures/operators.md) | x | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[Variables](data_structures/variables.md) | x | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[Strings](data_structures/strings.md) | x | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[Arrays](data_structures/arrays.md) | x | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[References](data_structures/references.md) | | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;Equality | | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[Tuples](data_structures/tuples.md) | | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[Sets](data_structures/sets.md) | | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;Dictionaries | | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;Abstract Base Classes | | | | x |
-&nbsp;&nbsp;&nbsp;&nbsp;[Linked Lists](data_structures/linked_lists.md) | | x | x |  |
-&nbsp;&nbsp;&nbsp;&nbsp;[Stacks](data_structures/stacks.md) | | x | x |  |
-&nbsp;&nbsp;&nbsp;&nbsp;[Queues](data_structures/queues.md) | | x | x |  |
-&nbsp;&nbsp;&nbsp;&nbsp;Implementing Collections | | x | x | |
-&nbsp;&nbsp;&nbsp;&nbsp;Trees | | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;Graphs | | x | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;Binary Search Trees | | | x | |
-&nbsp;&nbsp;&nbsp;&nbsp;Hash Tables | | | x | |
-&nbsp;&nbsp;&nbsp;&nbsp;Priority Queues | | | x | |
-&nbsp;&nbsp;&nbsp;&nbsp;Union-Find | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;[Built-in Types](data_structures/built_in_types.md) | x | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Operators](data_structures/operators.md) | x | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Variables](data_structures/variables.md) | x | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Strings](data_structures/strings.md) | x | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Arrays](data_structures/arrays.md) | x | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[References](data_structures/references.md) | | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;Equality | | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Tuples](data_structures/tuples.md) | | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Sets](data_structures/sets.md) | | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;Dictionaries | | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;Abstract Base Classes | | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Linked Lists](data_structures/linked_lists.md) | | x | | x |  |
+&nbsp;&nbsp;&nbsp;&nbsp;[Stacks](data_structures/stacks.md) | | x | x | x |  |
+&nbsp;&nbsp;&nbsp;&nbsp;[Queues](data_structures/queues.md) | | x | x | x |  |
+&nbsp;&nbsp;&nbsp;&nbsp;Implementing Collections | | x | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Trees | | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;Graphs | | x | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Binary Search Trees | | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Hash Tables | | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Priority Queues | | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Union-Find | | | | x | |
 **Algorithms**
-&nbsp;&nbsp;&nbsp;&nbsp;[Analysis of Algorithms](algorithms/analysis.md) | | x | x | |
-&nbsp;&nbsp;&nbsp;&nbsp;[Search](algorithms/search.md) | | x | x | |
-&nbsp;&nbsp;&nbsp;&nbsp;Traversal | | x | x | |
-&nbsp;&nbsp;&nbsp;&nbsp;Algorithmic Strategies | | | x | |
-&nbsp;&nbsp;&nbsp;&nbsp;Sorting | | | x | |
-&nbsp;&nbsp;&nbsp;&nbsp;Graph Algorithms | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;[Analysis of Algorithms](algorithms/analysis.md) | | x | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;[Search](algorithms/search.md) | | x | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Traversal | | x | x | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Algorithmic Strategies | | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Sorting | | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Graph Algorithms | | | | x | |
 **Style**
-&nbsp;&nbsp;&nbsp;&nbsp;[Documentation](style/documentation.md) | | x | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;[Omitting Needless Code](style/omitting_needless_code.md) | | x | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;[Names](style/names.md) | x | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[Defensive Programming](style/defensive_programming.md) | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Documentation](style/documentation.md) | | x |  | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Omitting Needless Code](style/omitting_needless_code.md) | | x | | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Names](style/names.md) | x | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Defensive Programming](style/defensive_programming.md) | | | | | x |
 **Object-Oriented Programming**
-&nbsp;&nbsp;&nbsp;&nbsp;[Classes and Initializers](oop/classes.md) | | x | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;[Methods](oop/methods.md) | | x | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;[Magic Methods](oop/magic.md) | | x | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;Inheritance | | | | x |
-&nbsp;&nbsp;&nbsp;&nbsp;Packages | | | | x |
-&nbsp;&nbsp;&nbsp;&nbsp;Exceptions | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Classes and Initializers](oop/classes.md) | | x | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Methods](oop/methods.md) | | x | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Magic Methods](oop/magic.md) | | x | | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Inheritance | | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Packages | | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Exceptions | | | | | x |
 **Libraries**
-&nbsp;&nbsp;&nbsp;&nbsp;[stdlib](libraries/stdlib.md) | | x | | |
-&nbsp;&nbsp;&nbsp;&nbsp;tkinter | | | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;numpy | | | | | x
-&nbsp;&nbsp;&nbsp;&nbsp;pandas | | | | | x
-&nbsp;&nbsp;&nbsp;&nbsp;scikit-learn | | | | | x
+&nbsp;&nbsp;&nbsp;&nbsp;[stdlib](libraries/stdlib.md) | | x | | | |
+&nbsp;&nbsp;&nbsp;&nbsp;tkinter | | | | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;numpy | | | x | | | x
+&nbsp;&nbsp;&nbsp;&nbsp;pandas | | | x | | | x
+&nbsp;&nbsp;&nbsp;&nbsp;scikit-learn | | | x | | | x
+&nbsp;&nbsp;&nbsp;&nbsp;tensorflow | | | x | | |
 **Software Development**
-&nbsp;&nbsp;&nbsp;&nbsp;Time Management | x | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[Iterative Development](software_development/iterative_development.md) | | x | x | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;[Pair Programming](software_development/pair_programming.md) | | x | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;[Testing](software_development/testing.md) | | x | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;[Debugging](software_development/debugging.md) | x | x | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;Teamwork | | | | x | x
-&nbsp;&nbsp;&nbsp;&nbsp;Extreme Programming | | | |  x|
-&nbsp;&nbsp;&nbsp;&nbsp;UML | | | | x |
-&nbsp;&nbsp;&nbsp;&nbsp;Object-Oriented Design | | | | x |
-&nbsp;&nbsp;&nbsp;&nbsp;Design Patterns | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Time Management | x | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Iterative Development](software_development/iterative_development.md) | | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Pair Programming](software_development/pair_programming.md) | | x | | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Testing](software_development/testing.md) | | x | | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Debugging](software_development/debugging.md) | x | x | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Teamwork | | | x | | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;Extreme Programming | | | | |  x|
+&nbsp;&nbsp;&nbsp;&nbsp;UML | | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Object-Oriented Design | | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Design Patterns | | | | | x |
 
 Topic | CS1 | CS2 | Algorithms | Software Development
 -|-|-|-|-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Pythonorama
-This repository holds topic summaries and questions for some of Lewis \& Clark introductory computer science courses based on the Python programming language.
-
-The contents and organization of this site owe to Peter Drake's [Drakepedia](https://github.com/PeterDrake/drakepedia/).
+This repository holds topic summaries and questions for some of Lewis \& Clark computer science courses based on the Python programming language.
 
 We have three purposes in creating this repository:
 1. To keep our own notes and useful links organized.
@@ -15,7 +13,46 @@ Questions are rated according to their difficulty:
 - :star::star: These questions may take a bit of thought, close reading, experimentation, or research.
 - :star::star::star: These questions require even more thought.
 
-The table below shows which topics I expect people to learn in which courses. (CS1 is taught in C, but for these topics C and Python are sufficiently similar.) Links are to existing pages in the Pythonorama.
+The table below shows which topics are covered in which courses. Links are to existing pages in Pythonorama. Note that CS 171 is taught in C, but the concepts are very similar between C and Python. DSCI 140 is taught in Python by Peter Drake, but in R by some other instructors.
+
+Topic | CS 171<br>(CS1) | CS 172<br>(CS2) | CS 383<br>(Algo) | CS 488<br>(SofDev) | DSCI 140<br>(DataSci)
+-|-|-|-|-|-
+<b>Development Tools</b> | | | | |
+&nbsp;&nbsp;&nbsp;&nbsp;[Command Line](development_tools/command_line.md) | x | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Visual Studio Code](development_tools/vs_code.md) | | x | | |
+&nbsp;&nbsp;&nbsp;&nbsp;PyCharm | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Git | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Jupyter / Google Colab | | | | | x
+<b>Control Structures</b> | | | | |
+&nbsp;&nbsp;&nbsp;&nbsp;[Your First Program](control_structures/your_first_program.md) | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[If Statements](control_structures/if_else.md) | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Loops](control_structures/loops.md) | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Functional Decomposition](control_structures/functional_decomposition.md) | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Recursion](control_structures/recursion.md) | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Higher-Order Functions | | | x | x |
+<b>Data Structures</b> | | | | |
+&nbsp;&nbsp;&nbsp;&nbsp;[Built-in Types](data_structures/built_in_types.md) | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Operators](data_structures/operators.md) | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Variables](data_structures/variables.md) | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Strings](data_structures/strings.md) | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Arrays](data_structures/arrays.md) | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[References](data_structures/references.md) | | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;Equality | | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Tuples](data_structures/tuples.md) | | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Sets](data_structures/sets.md) | | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;Dictionaries | | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;Abstract Base Classes | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Linked Lists](data_structures/linked_lists.md) | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Stacks](data_structures/stacks.md) | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Queues](data_structures/queues.md) | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Implementing Collections | | x | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Trees | | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;Graphs | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Binary Search Trees | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Hash Tables | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Priority Queues | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Union-Find | | | x | |
+<b>Algorithms</b> | | | | |
 
 Topic | CS1 | CS2 | Algorithms | Software Development
 -|-|-|-|-

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Questions are rated according to their difficulty:
 - :star::star: These questions may take a bit of thought, close reading, experimentation, or research.
 - :star::star::star: These questions require even more thought.
 
-The table below shows which topics are covered in which courses. Links are to existing pages in Pythonorama. Note that CS 171 is taught in C, but the concepts are very similar between C and Python. DSCI 140 is taught in Python by Peter Drake, but in R by some other instructors.
+The table below shows which topics are covered in which courses. Links are to existing pages in Pythonorama. CS 171 is taught in C, but the concepts are very similar between C and Python. DSCI 140 is taught in Python by Peter Drake, but in R by some other instructors.
 
 Topic | CS 171<br>(CS1) | CS 172<br>(CS2) | CS 369<br>(AI & ML) | CS 383<br>(Algo) | CS 488<br>(SofDev) | DSCI 140<br>(DataSci)
 -|-|-|-|-|-|-
@@ -89,14 +89,3 @@ Topic | CS 171<br>(CS1) | CS 172<br>(CS2) | CS 369<br>(AI & ML) | CS 383<br>(Alg
 &nbsp;&nbsp;&nbsp;&nbsp;UML | | | | | x |
 &nbsp;&nbsp;&nbsp;&nbsp;Object-Oriented Design | | | | | x |
 &nbsp;&nbsp;&nbsp;&nbsp;Design Patterns | | | | | x |
-
-Topic | CS1 | CS2 | Algorithms | Software Development
--|-|-|-|-
-Development Tools | [Command Line](development_tools/command_line.md)<br>Jupyter / Google Colab |[Visual Studio Code](development_tools/vs_code.md)<br>PyCharm | Git
-Control<br>Structures | [Your First Program](control_structures/your_first_program.md)<br>[If Statements](control_structures/if_else.md)<br>[Loops](control_structures/loops.md)<br>[Functional Decomposition](control_structures/functional_decomposition.md) | [Recursion](control_structures/recursion.md) | Higher-Order Functions |
-Data<br>Structures | [Built-in Types](data_structures/built_in_types.md)<br>[Operators](data_structures/operators.md)<br>[Variables](data_structures/variables.md)<br>[Strings](data_structures/strings.md)<br>[Arrays](data_structures/arrays.md)<br>Lists | [References](data_structures/references.md)<br>Equality<br>[Tuples](data_structures/tuples.md)<br>[Sets](data_structures/sets.md)<br>Dictionaries<br>Abstract Base Classes<br>[Linked Lists](data_structures/linked_lists.md)<br>[Stacks](data_structures/stacks.md)<br>[Queues](data_structures/queues.md)<br>Implementing Collections<br>Trees<br>Graphs | Binary Search Trees<br>Hash Tables<br>Priority Queues<br>Union-Find |
-Algorithms | | [Analysis of Algorithms](algorithms/analysis.md)<br>[Search](algorithms/search.md)<br>Traversal | Algorithmic Strategies<br>Sorting<br>Graph Algorithms |
-Style | | [Documentation](style/documentation.md)<br>[Omitting Needless Code](style/omitting_needless_code.md) | [Names](style/names.md)<br>[Defensive Programming](style/defensive_programming.md) |
-Object-<br>Oriented Programming | | [Classes and Initializers](oop/classes.md)<br>[Methods](oop/methods.md)<br>[Magic Methods](oop/magic.md) | Inheritance<br>Packages<br>Exceptions |
-Libraries | | [stdlib](libraries/stdlib.md) | |
-Software<br>Development | Time Management | [Iterative Development](software_development/iterative_development.md)<br>[Pair Programming](software_development/pair_programming.md)<br>[Testing](software_development/testing.md)<br>[Debugging](software_development/debugging.md) | | Teamwork<br>Extreme Programming<br>UML<br>Object-Oriented Design<br>Design Patterns

--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ The table below shows which topics are covered in which courses. Links are to ex
 
 Topic | CS 171<br>(CS1) | CS 172<br>(CS2) | CS 383<br>(Algo) | CS 488<br>(SofDev) | DSCI 140<br>(DataSci)
 -|-|-|-|-|-
-<b>Development Tools</b> | | | | |
+**Development Tools**
 &nbsp;&nbsp;&nbsp;&nbsp;[Command Line](development_tools/command_line.md) | x | x | x | x |
 &nbsp;&nbsp;&nbsp;&nbsp;[Visual Studio Code](development_tools/vs_code.md) | | x | | |
-&nbsp;&nbsp;&nbsp;&nbsp;PyCharm | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;PyCharm | | | x | x |
 &nbsp;&nbsp;&nbsp;&nbsp;Git | | | | x |
 &nbsp;&nbsp;&nbsp;&nbsp;Jupyter / Google Colab | | | | | x
-<b>Control Structures</b> | | | | |
+**Control Structures**
 &nbsp;&nbsp;&nbsp;&nbsp;[Your First Program](control_structures/your_first_program.md) | x | x | x | x | x
 &nbsp;&nbsp;&nbsp;&nbsp;[If Statements](control_structures/if_else.md) | x | x | x | x | x
 &nbsp;&nbsp;&nbsp;&nbsp;[Loops](control_structures/loops.md) | x | x | x | x | x
 &nbsp;&nbsp;&nbsp;&nbsp;[Functional Decomposition](control_structures/functional_decomposition.md) | x | x | x | x | x
 &nbsp;&nbsp;&nbsp;&nbsp;[Recursion](control_structures/recursion.md) | | x | x | x |
 &nbsp;&nbsp;&nbsp;&nbsp;Higher-Order Functions | | | x | x |
-<b>Data Structures</b> | | | | |
+**Data Structures**
 &nbsp;&nbsp;&nbsp;&nbsp;[Built-in Types](data_structures/built_in_types.md) | x | x | x | x | x
 &nbsp;&nbsp;&nbsp;&nbsp;[Operators](data_structures/operators.md) | x | x | x | x | x
 &nbsp;&nbsp;&nbsp;&nbsp;[Variables](data_structures/variables.md) | x | x | x | x | x
@@ -42,9 +42,9 @@ Topic | CS 171<br>(CS1) | CS 172<br>(CS2) | CS 383<br>(Algo) | CS 488<br>(SofDev
 &nbsp;&nbsp;&nbsp;&nbsp;[Sets](data_structures/sets.md) | | x | x | x | x
 &nbsp;&nbsp;&nbsp;&nbsp;Dictionaries | | x | x | x | x
 &nbsp;&nbsp;&nbsp;&nbsp;Abstract Base Classes | | | | x |
-&nbsp;&nbsp;&nbsp;&nbsp;[Linked Lists](data_structures/linked_lists.md) | | x | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;[Stacks](data_structures/stacks.md) | | x | x | x |
-&nbsp;&nbsp;&nbsp;&nbsp;[Queues](data_structures/queues.md) | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Linked Lists](data_structures/linked_lists.md) | | x | x |  |
+&nbsp;&nbsp;&nbsp;&nbsp;[Stacks](data_structures/stacks.md) | | x | x |  |
+&nbsp;&nbsp;&nbsp;&nbsp;[Queues](data_structures/queues.md) | | x | x |  |
 &nbsp;&nbsp;&nbsp;&nbsp;Implementing Collections | | x | x | |
 &nbsp;&nbsp;&nbsp;&nbsp;Trees | | x | x | x | x
 &nbsp;&nbsp;&nbsp;&nbsp;Graphs | | x | x | x |
@@ -52,7 +52,42 @@ Topic | CS 171<br>(CS1) | CS 172<br>(CS2) | CS 383<br>(Algo) | CS 488<br>(SofDev
 &nbsp;&nbsp;&nbsp;&nbsp;Hash Tables | | | x | |
 &nbsp;&nbsp;&nbsp;&nbsp;Priority Queues | | | x | |
 &nbsp;&nbsp;&nbsp;&nbsp;Union-Find | | | x | |
-<b>Algorithms</b> | | | | |
+**Algorithms**
+&nbsp;&nbsp;&nbsp;&nbsp;[Analysis of Algorithms](algorithms/analysis.md) | | x | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;[Search](algorithms/search.md) | | x | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Traversal | | x | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Algorithmic Strategies | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Sorting | | | x | |
+&nbsp;&nbsp;&nbsp;&nbsp;Graph Algorithms | | | x | |
+**Style**
+&nbsp;&nbsp;&nbsp;&nbsp;[Documentation](style/documentation.md) | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Omitting Needless Code](style/omitting_needless_code.md) | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Names](style/names.md) | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Defensive Programming](style/defensive_programming.md) | | | | x |
+**Object-Oriented Programming**
+&nbsp;&nbsp;&nbsp;&nbsp;[Classes and Initializers](oop/classes.md) | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Methods](oop/methods.md) | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Magic Methods](oop/magic.md) | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Inheritance | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Packages | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Exceptions | | | | x |
+**Libraries**
+&nbsp;&nbsp;&nbsp;&nbsp;[stdlib](libraries/stdlib.md) | | x | | |
+&nbsp;&nbsp;&nbsp;&nbsp;tkinter | | | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;numpy | | | | | x
+&nbsp;&nbsp;&nbsp;&nbsp;pandas | | | | | x
+&nbsp;&nbsp;&nbsp;&nbsp;scikit-learn | | | | | x
+**Software Development**
+&nbsp;&nbsp;&nbsp;&nbsp;Time Management | x | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Iterative Development](software_development/iterative_development.md) | | x | x | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;[Pair Programming](software_development/pair_programming.md) | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Testing](software_development/testing.md) | | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;[Debugging](software_development/debugging.md) | x | x | x | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Teamwork | | | | x | x
+&nbsp;&nbsp;&nbsp;&nbsp;Extreme Programming | | | |  x|
+&nbsp;&nbsp;&nbsp;&nbsp;UML | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Object-Oriented Design | | | | x |
+&nbsp;&nbsp;&nbsp;&nbsp;Design Patterns | | | | x |
 
 Topic | CS1 | CS2 | Algorithms | Software Development
 -|-|-|-|-


### PR DESCRIPTION
I've updated the contents page, which should give us more horizontal space for section titles and allow finer-grained notes on what happens where.